### PR TITLE
feat: Add GetFloatingClientMetadata method

### DIFF
--- a/cryptlex/lexfloatclient/lexfloatclient.py
+++ b/cryptlex/lexfloatclient/lexfloatclient.py
@@ -268,6 +268,28 @@ class LexFloatClient:
             raise LexFloatClientException(status)
 
     @staticmethod
+    def GetFloatingClientMetadata(key):
+        """Gets the value of the floating client metadata.
+
+        Args:
+                key (str): metadata key to retrieve the value
+
+        Raises:
+                LexFloatClientException
+
+        Returns:
+                str: value of metadata for the key
+        """
+        cstring_key = LexFloatClientNative.get_ctype_string(key)
+        buffer_size = 256
+        buffer = LexFloatClientNative.get_ctype_string_buffer(buffer_size)
+        status = LexFloatClientNative.GetFloatingClientMetadata(
+            cstring_key, buffer, buffer_size)
+        if status != LexFloatStatusCodes.LF_OK:
+            raise LexFloatClientException(status)
+        return LexFloatClientNative.byte_to_string(buffer.value)
+
+    @staticmethod
     def RequestFloatingLicense():
         """Sends the request to lease the license from the LexFloatServer.
 

--- a/cryptlex/lexfloatclient/lexfloatclient.py
+++ b/cryptlex/lexfloatclient/lexfloatclient.py
@@ -281,7 +281,7 @@ class LexFloatClient:
                 str: value of the floating client metadata
         """
         cstring_key = LexFloatClientNative.get_ctype_string(key)
-        buffer_size = 256
+        buffer_size = 4096
         buffer = LexFloatClientNative.get_ctype_string_buffer(buffer_size)
         status = LexFloatClientNative.GetFloatingClientMetadata(
             cstring_key, buffer, buffer_size)

--- a/cryptlex/lexfloatclient/lexfloatclient.py
+++ b/cryptlex/lexfloatclient/lexfloatclient.py
@@ -278,7 +278,7 @@ class LexFloatClient:
                 LexFloatClientException
 
         Returns:
-                str: value of metadata for the key
+                str: value of the floating client metadata
         """
         cstring_key = LexFloatClientNative.get_ctype_string(key)
         buffer_size = 256

--- a/cryptlex/lexfloatclient/lexfloatclient_native.py
+++ b/cryptlex/lexfloatclient/lexfloatclient_native.py
@@ -163,7 +163,6 @@ GetFloatingClientMetadata = library.GetFloatingClientMetadata
 GetFloatingClientMetadata.argtypes = [CSTRTYPE, STRTYPE, c_uint32]
 GetFloatingClientMetadata.restype = c_int
 
-
 RequestFloatingLicense = library.RequestFloatingLicense
 RequestFloatingLicense.argtypes = []
 RequestFloatingLicense.restype = c_int

--- a/cryptlex/lexfloatclient/lexfloatclient_native.py
+++ b/cryptlex/lexfloatclient/lexfloatclient_native.py
@@ -159,6 +159,11 @@ GetFloatingClientMeterAttributeUses = library.GetFloatingClientMeterAttributeUse
 GetFloatingClientMeterAttributeUses.argtypes = [CSTRTYPE, POINTER(c_uint32)]
 GetFloatingClientMeterAttributeUses.restype = c_int
 
+GetFloatingClientMetadata = library.GetFloatingClientMetadata
+GetFloatingClientMetadata.argtypes = [CSTRTYPE, STRTYPE, c_uint32]
+GetFloatingClientMetadata.restype = c_int
+
+
 RequestFloatingLicense = library.RequestFloatingLicense
 RequestFloatingLicense.argtypes = []
 RequestFloatingLicense.restype = c_int


### PR DESCRIPTION
GetFloatingClientMetadata, to retrieve the value of the floating client metadata. The method takes a key as an argument and returns the corresponding value. 